### PR TITLE
Improved chat context for Markov bot responses

### DIFF
--- a/bot.h
+++ b/bot.h
@@ -442,6 +442,8 @@ typedef struct {
    unsigned newmsg : 1; // set true if the bot should check a new message from another player
    char message[255];
    char msgstart[255];
+   bool msg_team;
+   char msgLocation[64];
    float f_roleSayDelay; // used to stop bots reporting stuff too often
    float f_last_reply_time; // last time bot replied to chat
 


### PR DESCRIPTION
## Summary
- track if chat is team-only and where the speaker is
- integrate location context when training the Markov chain
- let bots respond with generated phrases that include map location
- initialize new message fields for each bot

## Testing
- `make depend`
- `make` *(fails: bits/libc-header-start.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686f11008730833088f792cb14f28852