### PR TITLE
Improve combat heuristics

### DIFF
--- a/bot.cpp
+++ b/bot.cpp
@@ -3778,6 +3778,7 @@ void BotThink(bot_t *pBot) {
    BotUpdateWeapon(pBot);
    BotUpdateChat(pBot);
    BotUpdateCombat(pBot);
+   BotApplyCombatState(pBot);
    BotUpdateAim(pBot);
    BotUpdateReaction(pBot);
    BotApplyNavState(pBot);

--- a/bot_fsm.cpp
+++ b/bot_fsm.cpp
@@ -424,8 +424,12 @@ void BotUpdateWeapon(bot_t *pBot) {
             next = WEAPON_GRENADE;
     }
 
-    if(pBot->desired_combat_state == COMBAT_RETREAT && pBot->current_weapon.iAmmo2 > 0)
-        next = WEAPON_SECONDARY;
+    if(pBot->desired_combat_state == COMBAT_RETREAT && pBot->current_weapon.iAmmo2 > 0) {
+        if(pBot->visEnemyCount > pBot->visAllyCount && random_long(0,100) < 40)
+            next = WEAPON_GRENADE;
+        else
+            next = WEAPON_SECONDARY;
+    }
 
     pBot->desired_weapon_state = static_cast<int>(next);
 }
@@ -489,6 +493,13 @@ void BotUpdateCombat(bot_t *pBot) {
         else if(dist < 200.0f)
             next = COMBAT_ATTACK;
         else if(dist > 600.0f)
+            next = COMBAT_APPROACH;
+
+        if(PlayerHealthPercent(pBot->pEdict) < 30 &&
+           pBot->visEnemyCount > pBot->visAllyCount)
+            next = COMBAT_RETREAT;
+        else if(PlayerHealthPercent(pBot->pEdict) > 60 &&
+                pBot->visAllyCount > pBot->visEnemyCount + 1)
             next = COMBAT_APPROACH;
     }
 
@@ -660,5 +671,10 @@ void BotUpdateReaction(bot_t *pBot) {
         next = REACT_ALERT;
     else if(pBot->desired_reaction_state == REACT_ALERT && !pBot->enemy.ptr)
         next = REACT_CALM;
+
+    if(PlayerHealthPercent(pBot->pEdict) < 40 &&
+       pBot->visEnemyCount > pBot->visAllyCount + 1)
+        next = REACT_PANIC;
+
     pBot->desired_reaction_state = (int)next;
 }


### PR DESCRIPTION
## Summary
- adjust combat evaluation with ally/enemy counts
- prefer grenades while retreating when outnumbered
- panic when heavily outnumbered
- apply combat state immediately in BotThink

## Testing
- `make` *(fails: ‘InitialiseNewJob’ was not declared in this scope)*

------
https://chatgpt.com/codex/tasks/task_e_686f110dabd08330b7228745928e5e15