### PR TITLE
Enhance Markov generator with n‑gram support

### DIFF
--- a/bot_markov.cpp
+++ b/bot_markov.cpp
@@ -1,15 +1,20 @@
 #include "bot_markov.h"
-#include <map>
+#include <unordered_map>
 #include <vector>
 #include <string>
 #include <cstdlib>
 #include <cstring>
 #include <cctype>
+#include <sstream>
+#include <deque>
+#include <fstream>
 
-static std::map<std::string, std::vector<std::string> > g_chain;
+static std::unordered_map<std::string, std::vector<std::string>> g_chain;
+static size_t g_order = 3; // default to trigram
 
 void MarkovInit() {
     g_chain.clear();
+    g_order = 3;
 }
 
 static void add_pair(const std::string &w1, const std::string &w2) {
@@ -18,15 +23,22 @@ static void add_pair(const std::string &w1, const std::string &w2) {
 
 void MarkovAddSentence(const char *line) {
     if(!line) return;
-    std::string prev;
+    std::deque<std::string> window;
     char word[32];
     const char *p = line;
     int n;
     while(sscanf(p, "%31s%n", word, &n) == 1) {
         for(int i=0; word[i]; ++i) word[i] = static_cast<char>(tolower(word[i]));
-        if(!prev.empty())
-            add_pair(prev, word);
-        prev = word;
+        window.push_back(word);
+        if(window.size() == g_order) {
+            std::string prefix;
+            for(size_t i=0; i+1<window.size(); ++i) {
+                if(i) prefix.push_back(' ');
+                prefix += window[i];
+            }
+            add_pair(prefix, window.back());
+            window.pop_front();
+        }
         p += n;
         while(*p && isspace(*p)) ++p;
     }
@@ -38,62 +50,123 @@ void MarkovGenerate(char *out, size_t maxLen) {
         out[0] = '\0';
         return;
     }
+
     size_t index = rand() % g_chain.size();
-    std::map<std::string, std::vector<std::string> >::iterator it = g_chain.begin();
-    for(size_t i=0; i<index; ++i) ++it;
-    std::string word = it->first;
+    auto it = g_chain.begin();
+    std::advance(it, index);
+    std::string prefix = it->first;
+    std::vector<std::string> words;
+    {
+        std::istringstream iss(prefix);
+        std::string tok;
+        while(iss >> tok) words.push_back(tok);
+    }
+
     size_t len = 0;
     out[0] = '\0';
-    for(int step=0; step<12 && len + word.length() + 1 < maxLen; ++step) {
-        if(len) {
-            out[len++] = ' ';
-        }
-        std::strncpy(out+len, word.c_str(), maxLen - len - 1);
-        len += word.length();
+    for(const auto &w : words) {
+        if(len + w.length() + 1 >= maxLen) break;
+        if(len) out[len++] = ' ';
+        std::strncpy(out+len, w.c_str(), maxLen - len - 1);
+        len += w.length();
         out[len] = '\0';
-        const std::vector<std::string> &next = g_chain[word];
-        if(next.empty())
+    }
+
+    for(int step=0; step<12; ++step) {
+        auto vit = g_chain.find(prefix);
+        if(vit == g_chain.end() || vit->second.empty())
             break;
-        word = next[rand() % next.size()];
+        const std::string &next = vit->second[rand() % vit->second.size()];
+        if(len + next.length() + 1 >= maxLen) break;
+        if(len) out[len++] = ' ';
+        std::strncpy(out+len, next.c_str(), maxLen - len - 1);
+        len += next.length();
+        out[len] = '\0';
+
+        words.push_back(next);
+        if(words.size() > g_order - 1)
+            words.erase(words.begin());
+        prefix.clear();
+        for(size_t i=0; i<words.size(); ++i) {
+            if(i) prefix.push_back(' ');
+            prefix += words[i];
+        }
     }
     out[len] = '\0';
 }
 
 bool MarkovSave(const char *file) {
     if(!file) return false;
-    FILE *fp = fopen(file, "w");
-    if(!fp) return false;
-    for(std::map<std::string, std::vector<std::string> >::iterator it = g_chain.begin(); it != g_chain.end(); ++it) {
-        fprintf(fp, "%s %u", it->first.c_str(), (unsigned)it->second.size());
-        for(size_t i=0; i<it->second.size(); ++i)
-            fprintf(fp, " %s", it->second[i].c_str());
-        fprintf(fp, "\n");
+    std::ofstream out(file);
+    if(!out) return false;
+    out << "N " << g_order << '\n';
+    for(const auto &it : g_chain) {
+        out << it.first << ' ' << it.second.size();
+        for(const auto &n : it.second)
+            out << ' ' << n;
+        out << '\n';
     }
-    fclose(fp);
     return true;
 }
 
 bool MarkovLoad(const char *file) {
     if(!file) return false;
-    FILE *fp = fopen(file, "r");
-    if(!fp) return false;
+    std::ifstream in(file);
+    if(!in) return false;
     g_chain.clear();
-    char line[512];
-    while(fgets(line, sizeof(line), fp)) {
-        char *tok = strtok(line, " \t\n");
-        if(!tok) continue;
-        std::string first = tok;
-        tok = strtok(NULL, " \t\n");
-        if(!tok) continue;
-        int count = atoi(tok);
+
+    std::string line;
+    if(!std::getline(in, line))
+        return true;
+
+    std::istringstream hdr(line);
+    std::string tok;
+    if(hdr >> tok && tok == "N") {
+        hdr >> g_order;
+    } else {
+        g_order = 2; // old format
+        std::istringstream iss(line);
+        std::string first;
+        if(!(iss >> first)) return true;
+        int count = 0;
+        iss >> count;
         for(int i=0;i<count;i++) {
-            tok = strtok(NULL, " \t\n");
-            if(!tok) break;
-            add_pair(first, tok);
-            first = tok;
+            std::string w;
+            if(!(iss >> w)) break;
+            add_pair(first, w);
+            first = w;
         }
     }
-    fclose(fp);
+
+    while(std::getline(in, line)) {
+        if(line.empty()) continue;
+        std::istringstream iss(line);
+        if(g_order == 2) {
+            std::string first;
+            int count;
+            if(!(iss >> first >> count)) continue;
+            for(int i=0;i<count;i++) {
+                std::string w;
+                if(!(iss >> w)) break;
+                add_pair(first, w);
+                first = w;
+            }
+        } else {
+            std::vector<std::string> tokens;
+            std::string w;
+            while(iss >> w) tokens.push_back(w);
+            if(tokens.size() < g_order) continue;
+            std::string prefix;
+            for(size_t i=0;i<g_order-1;i++) {
+                if(i) prefix.push_back(' ');
+                prefix += tokens[i];
+            }
+            size_t count = std::stoul(tokens[g_order-1]);
+            size_t pos = g_order;
+            for(size_t i=0;i<count && pos < tokens.size(); ++i, ++pos)
+                add_pair(prefix, tokens[pos]);
+        }
+    }
     return true;
 }
 


### PR DESCRIPTION
## Summary
- support configurable n-gram chains in `bot_markov.cpp`
- switch to `unordered_map` for faster lookups
- extend add/generate logic for n-grams
- improve load/save format (with backward compatibility)

## Testing
- `make -s` *(fails: fatal error: bits/libc-header-start.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686f14070f408330b644a21c7cb55a7d