### PR TITLE
Add planner module

### DIFF
--- a/bot.cpp
+++ b/bot.cpp
@@ -3799,6 +3799,7 @@ void BotThink(bot_t *pBot) {
    // these four functions essentially handle the core of bot behaviour
    BotSenseEnvironment(pBot);
    BotFight(pBot);
+   PlannerThink(pBot);
    BotJobThink(pBot);
    BotRunJobs(pBot);
    BotUpdateState(pBot);

--- a/bot_func.h
+++ b/bot_func.h
@@ -60,6 +60,10 @@ bool BotFireWeapon(const Vector &v_enemy, bot_t *pBot, int weapon_choice);
 
 void BotShootAtEnemy(bot_t *pBot);
 
+// planner helpers
+void PlannerInit(bot_t *pBot);
+void PlannerThink(bot_t *pBot);
+
 // finite state machine helpers
 void BotFSMInit(BotFSM *fsm, BotState initial);
 BotState BotFSMNextState(BotFSM *fsm);

--- a/bot_planner.cpp
+++ b/bot_planner.cpp
@@ -1,0 +1,41 @@
+#include "bot.h"
+#include "bot_fsm.h"
+#include "bot_job_think.h"
+#include "bot_func.h"
+
+// Returns the highest base priority currently stored in the job buffer.
+static int PlannerHighestPriority(const bot_t *pBot) {
+    int highest = PRIORITY_NONE;
+    for(int i = 0; i < JOB_BUFFER_MAX; ++i) {
+        if(pBot->jobType[i] != JOB_NONE) {
+            int pri = jl[pBot->jobType[i]].basePriority;
+            if(pri > highest)
+                highest = pri;
+        }
+    }
+    return highest;
+}
+
+// Initialize planner related state for the bot.
+void PlannerInit(bot_t *pBot) {
+    if(!pBot)
+        return;
+    JobFSMInit(&pBot->jobFsm, JOB_ROAM);
+}
+
+// Select and buffer long term goals based on the job FSM and current priorities.
+void PlannerThink(bot_t *pBot) {
+    if(!pBot)
+        return;
+
+    const int next = JobFSMNextState(&pBot->jobFsm);
+    const int candidatePriority = jl[next].basePriority;
+
+    if(candidatePriority >= PlannerHighestPriority(pBot)) {
+        job_struct *newJob = InitialiseNewJob(pBot, next, true);
+        if(newJob)
+            SubmitNewJob(pBot, next, newJob);
+    }
+}
+
+

--- a/meson.build
+++ b/meson.build
@@ -194,6 +194,7 @@ sourceFiles = files (
    'bot_job_assessors.cpp',
    'bot_job_functions.cpp',
    'bot_job_think.cpp',
+   'bot_planner.cpp',
    'bot_navigate.cpp',
    'bot_start.cpp',
    'botcam.cpp',


### PR DESCRIPTION
## Summary
- introduce `bot_planner.cpp` with PlannerInit and PlannerThink
- expose planner functions in `bot_func.h`
- integrate planner into `BotThink`
- include planner file in the build

## Testing
- `make -n` *(fails: missing binary operator error)*
- `meson compile -C build` *(fails: `meson` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f19a94ae8833096407769262c8937