### PR TITLE
Improve FSM initialization defaults

### DIFF
--- a/bot_fsm.cpp
+++ b/bot_fsm.cpp
@@ -185,14 +185,27 @@ static void MoveFSMUpdateCounts(MoveFSM *fsm, int from, int to) {
 
 void MoveFSMInit(MoveFSM *fsm, MoveState initial) {
     fsm->current = fsm->previous = initial;
+    bool uniform = true;
+    for(int i = 0; i < MOVE_STATE_COUNT && uniform; ++i)
+        for(int j = 0; j < MOVE_STATE_COUNT && uniform; ++j)
+            if(gMoveCounts[i][j] != 1)
+                uniform = false;
+
+    static const unsigned defaults[MOVE_STATE_COUNT][MOVE_STATE_COUNT] = {
+        {8, 1, 1},  // from NORMAL
+        {6, 3, 1},  // from HEAL
+        {6, 1, 3}   // from STAB
+    };
+
     for(int i = 0; i < MOVE_STATE_COUNT; ++i) {
         unsigned total = 0;
         for(int j = 0; j < MOVE_STATE_COUNT; ++j) {
-            fsm->counts[i][j] = gMoveCounts[i][j] ? gMoveCounts[i][j] : 1;
+            fsm->counts[i][j] = uniform ? defaults[i][j]
+                                       : (gMoveCounts[i][j] ? gMoveCounts[i][j] : 1);
             total += fsm->counts[i][j];
         }
         for(int j = 0; j < MOVE_STATE_COUNT; ++j)
-            fsm->transition[i][j] = (float)fsm->counts[i][j] / (float)total;
+            fsm->transition[i][j] = static_cast<float>(fsm->counts[i][j]) / (float)total;
     }
 }
 
@@ -297,14 +310,28 @@ static void WeaponFSMUpdateCounts(WeaponFSM *fsm, int from, int to) {
 
 void WeaponFSMInit(WeaponFSM *fsm, WeaponState initial) {
     fsm->current = fsm->previous = initial;
+    bool uniform = true;
+    for(int i = 0; i < WEAPON_STATE_COUNT && uniform; ++i)
+        for(int j = 0; j < WEAPON_STATE_COUNT && uniform; ++j)
+            if(gWeaponCounts[i][j] != 1)
+                uniform = false;
+
+    static const unsigned defaults[WEAPON_STATE_COUNT][WEAPON_STATE_COUNT] = {
+        {7, 2, 1, 1},  // from PRIMARY
+        {4, 5, 1, 1},  // from SECONDARY
+        {6, 1, 3, 0},  // from MELEE
+        {7, 1, 1, 1}   // from GRENADE
+    };
+
     for(int i = 0; i < WEAPON_STATE_COUNT; ++i) {
         unsigned total = 0;
         for(int j = 0; j < WEAPON_STATE_COUNT; ++j) {
-            fsm->counts[i][j] = gWeaponCounts[i][j] ? gWeaponCounts[i][j] : 1;
+            fsm->counts[i][j] = uniform ? defaults[i][j]
+                                       : (gWeaponCounts[i][j] ? gWeaponCounts[i][j] : 1);
             total += fsm->counts[i][j];
         }
         for(int j = 0; j < WEAPON_STATE_COUNT; ++j)
-            fsm->transition[i][j] = (float)fsm->counts[i][j] / (float)total;
+            fsm->transition[i][j] = static_cast<float>(fsm->counts[i][j]) / (float)total;
     }
 }
 

--- a/bot_fsm.h
+++ b/bot_fsm.h
@@ -5,9 +5,9 @@
 
 enum BotState {
     BOT_STATE_IDLE = 0,
-    BOT_STATE_ROAM,
-    BOT_STATE_ATTACK,
-    BOT_STATE_DEFEND,
+    BOT_STATE_ROAM,    // currently unused
+    BOT_STATE_ATTACK,  // currently unused
+    BOT_STATE_DEFEND,  // currently unused
     BOT_STATE_COUNT
 };
 
@@ -24,6 +24,11 @@ enum MoveState {
     MOVE_STAB,
     MOVE_STATE_COUNT
 };
+
+// Typical transitions:
+//  - MOVE_NORMAL -> MOVE_HEAL when health is low
+//  - MOVE_NORMAL -> MOVE_STAB when closing on an enemy
+//  - Other states usually return to MOVE_NORMAL once finished
 
 struct MoveFSM {
     MoveState current;
@@ -47,6 +52,11 @@ enum WeaponState {
     WEAPON_STATE_COUNT
 };
 
+// Typical transitions:
+//  - Players tend to stay with WEAPON_PRIMARY
+//  - Temporary switches to SECONDARY or MELEE happen in close combat
+//  - GRENADE usage is rare and usually followed by returning to PRIMARY
+
 struct WeaponFSM {
     WeaponState current;
     WeaponState previous;
@@ -62,6 +72,11 @@ enum ChatState {
     CHAT_STATE_COUNT
 };
 
+// Expected behaviour:
+//  - CHAT_IDLE is the default
+//  - GREET is triggered at round start or when seeing allies
+//  - KILL and DEATH are short lived states after combat events
+
 struct ChatFSM {
     ChatState current;
     ChatState previous;
@@ -75,6 +90,8 @@ enum AimState {
     AIM_FEET,
     AIM_STATE_COUNT
 };
+
+// Bots favour AIM_BODY but may switch to HEAD for weak enemies
 
 struct AimFSM {
     AimState current;
@@ -91,6 +108,9 @@ enum CombatState {
     COMBAT_STATE_COUNT
 };
 
+// Approach and attack are common transitions when an enemy is visible
+// Bots retreat when low on health or outnumbered
+
 struct CombatFSM {
     CombatState current;
     CombatState previous;
@@ -105,6 +125,10 @@ enum ReactionState {
     REACT_STATE_COUNT
 };
 
+// Transitions depend on nearby allies and health:
+//  - ALERT when an enemy is spotted
+//  - PANIC when health is critical
+
 struct ReactionFSM {
     ReactionState current;
     ReactionState previous;
@@ -118,6 +142,9 @@ enum NavState {
     NAV_JUMP,
     NAV_STATE_COUNT
 };
+
+// Bots mostly travel straight, strafing or jumping when obstacles or
+// threats require quick movement
 
 struct NavFSM {
     NavState current;


### PR DESCRIPTION
## Summary
- adjust `MoveFSMInit` to bias initial state transitions toward normal movement
- adjust `WeaponFSMInit` to mimic typical weapon usage
- document expected transitions and mark unused bot states

## Testing
- `make` *(fails: missing glibc macros)*

------
https://chatgpt.com/codex/tasks/task_e_686f19b9ce988330bf0a184a6b64c4a2