### PR TITLE
Track opponent behavior

### DIFF
--- a/bot_combat.cpp
+++ b/bot_combat.cpp
@@ -819,6 +819,13 @@ static edict_t *BotFindEnemy(bot_t *pBot) {
 
             // see if the bot can see the player...
             if (FInViewCone(vecEnd, pEdict) && FVisible(vecEnd, pEdict)) {
+               const int oppIndex = ENTINDEX(pPlayer) - 1;
+               if (oppIndex >= 0 && oppIndex < MAX_OPPONENTS) {
+                  OpponentRememberWeapon(pBot->opponents[oppIndex], pPlayer->v.weaponmodel);
+                  const int wp = WaypointFindNearest_E(pPlayer, REACHABLE_RANGE, UTIL_GetTeam(pPlayer));
+                  if (wp != -1)
+                     OpponentRememberWaypoint(pBot->opponents[oppIndex], wp);
+               }
                const float distance = (pPlayer->v.origin - pEdict->v.origin).Length();
 
                // count the number of visible enemies nearby

--- a/bot_fsm.cpp
+++ b/bot_fsm.cpp
@@ -539,6 +539,13 @@ void BotUpdateCombat(bot_t *pBot) {
         Vector diff = pBot->enemy.ptr->v.origin - pBot->pEdict->v.origin;
         const float dist = diff.Length();
 
+        const int oppIdx = ENTINDEX(pBot->enemy.ptr) - 1;
+        if(oppIdx >= 0 && oppIdx < MAX_OPPONENTS) {
+            int fav = OpponentFavoriteWeapon(pBot->opponents[oppIdx]);
+            if(fav == TF_WEAPON_SNIPERRIFLE && dist > 300.0f)
+                next = COMBAT_APPROACH;
+        }
+
         if(pBot->pEdict->v.health < 25 || pBot->desired_reaction_state == REACT_PANIC)
             next = COMBAT_RETREAT;
         else if(pBot->desired_reaction_state == REACT_ALERT)
@@ -643,6 +650,15 @@ NavState NavFSMNextState(NavFSM *fsm) {
 void BotUpdateNavigation(bot_t *pBot) {
     if(!pBot) return;
     NavState next = NavFSMNextState(&pBot->navFsm);
+
+    if(pBot->enemy.ptr) {
+        const int oppIdx = ENTINDEX(pBot->enemy.ptr) - 1;
+        if(oppIdx >= 0 && oppIdx < MAX_OPPONENTS) {
+            int favWp = OpponentFavoredWaypoint(pBot->opponents[oppIdx]);
+            if(favWp == pBot->current_wp)
+                next = NAV_STRAFE;
+        }
+    }
 
     if(pBot->desired_reaction_state == REACT_PANIC)
         next = NAV_STRAFE;

--- a/bot_navigate.cpp
+++ b/bot_navigate.cpp
@@ -952,6 +952,13 @@ static void BotHandleLadderTraffic(bot_t *pBot) {
 
          // skip invalid players
          if (pPlayer && !pPlayer->free && pPlayer == tr.pHit) {
+            const int oppIndex = ENTINDEX(pPlayer) - 1;
+            if (oppIndex >= 0 && oppIndex < MAX_OPPONENTS) {
+               OpponentRememberWeapon(pBot->opponents[oppIndex], pPlayer->v.weaponmodel);
+               const int wp = WaypointFindNearest_E(pPlayer, REACHABLE_RANGE, UTIL_GetTeam(pPlayer));
+               if (wp != -1)
+                  OpponentRememberWaypoint(pBot->opponents[oppIndex], wp);
+            }
             // jump off the ladder
             pBot->pEdict->v.button = 0; // in case IN_FORWARD is active
             pBot->pEdict->v.button |= IN_JUMP;


### PR DESCRIPTION
## Summary
- store opponent habit data in `OpponentInfo`
- record seen weapons and waypoints for players
- react to known sniper weapons in combat state updates
- strafe when at an enemy's favored waypoint

## Testing
- `make` *(fails: missing binary operator before token)*

------
https://chatgpt.com/codex/tasks/task_e_686f19b36a4883308cbfbb18fbd0371c