### PR TITLE
Limit Markov save and add debug logging

### DIFF
--- a/bot.cpp
+++ b/bot.cpp
@@ -312,6 +312,7 @@ void BotSpawnInit(bot_t *pBot) {
 
    pBot->strafe_mod = STRAFE_MOD_NORMAL;
    pBot->f_last_reply_time = 0.0f;
+   pBot->f_markov_check_time = 0.0f;
    pBot->msg_team = false;
    pBot->msgLocation[0] = '\0';
 
@@ -939,6 +940,7 @@ void BotCreate(edict_t *pPlayer, const char *arg1, const char *arg2, const char 
         pBot->msg_team = false;
         pBot->msgLocation[0] = '\0';
         pBot->f_last_reply_time = 0.0f;
+        pBot->f_markov_check_time = 0.0f;
       }
 
       if (mod_id == TFC_DLL)
@@ -3660,7 +3662,10 @@ void BotThink(bot_t *pBot) {
       UTIL_BuildFileName(mkfile, 255, (char*)"foxbot_markov.dat", NULL);
       mk_inited = true;
    }
-   MarkovPeriodicSave(mkfile, pBot->f_think_time);
+   if(pBot->f_markov_check_time != pBot->f_think_time) {
+      MarkovPeriodicSave(mkfile, pBot->f_think_time);
+      pBot->f_markov_check_time = pBot->f_think_time;
+   }
    FSMPeriodicSave(pBot->f_think_time);
 
    if(pBot->f_next_ping_update <= pBot->f_think_time) {

--- a/bot.h
+++ b/bot.h
@@ -29,6 +29,9 @@
 #define BOT_H
 
 #include "osdep.h"
+
+struct bot_t;
+struct job_struct;
 #include "bot_fsm.h"
 #include <cstring>
 
@@ -447,9 +450,10 @@ typedef struct {
    char message[255];
    char msgstart[255];
    bool msg_team;
-   char msgLocation[64];
-   float f_roleSayDelay; // used to stop bots reporting stuff too often
-   float f_last_reply_time; // last time bot replied to chat
+  char msgLocation[64];
+  float f_roleSayDelay; // used to stop bots reporting stuff too often
+  float f_last_reply_time; // last time bot replied to chat
+  float f_markov_check_time; // last frame MarkovPeriodicSave was attempted
 
    // Engineer variables /////////////
    unsigned has_sentry : 1;    // set true if the bot owns a sentry gun

--- a/bot_job_think.h
+++ b/bot_job_think.h
@@ -28,6 +28,9 @@
 #ifndef BOT_JOB_THINK_H
 #define BOT_JOB_THINK_H
 
+struct bot_t;
+struct job_struct;
+
 // list of job types that the bots can try to accomplish
 enum knownJobTypes {
    JOB_NONE = -1,

--- a/bot_markov.cpp
+++ b/bot_markov.cpp
@@ -200,6 +200,7 @@ void MarkovPeriodicSave(const char *file, float currentTime) {
     if(currentTime >= g_next_save_time) {
         if(file)
             MarkovSave(file);
+        UTIL_BotLogPrintf("MarkovPeriodicSave: saved %s at %f\n", file ? file : "(null)", currentTime);
         g_next_save_time = currentTime + 120.0f;
     }
 }


### PR DESCRIPTION
## Summary
- ensure `MarkovPeriodicSave` is invoked at most once per frame
- track last Markov save attempt per bot
- log when Markov data is saved for troubleshooting
- forward declare required structs

## Testing
- `make -s` *(fails: invalid use of incomplete type)*

------
https://chatgpt.com/codex/tasks/task_e_686f19bceb488330a6faf8357d070a9b