### PR TITLE
Implement bot coordination and signaling

### DIFF
--- a/bot.h
+++ b/bot.h
@@ -340,6 +340,14 @@ static inline int OpponentFavoredWaypoint(const OpponentInfo &info) {
    return best;
 }
 
+typedef struct {
+   edict_t *bot;
+   edict_t *enemy;
+   int combat_state;
+   int nav_state;
+   float last_update;
+} NearbyBotState;
+
 // this is the core data structure used for each bot
 typedef struct {
    bool is_used; // set true to indicate an active bot
@@ -477,6 +485,9 @@ typedef struct {
    Vector lastAllyVector;       // where the last seen ally was seen last
    float f_lastAllySeenTime;    // when the bot last saw an ally
    float f_alliedMedicSeenTime; // when the bot last saw a friendly medic
+
+   short nearbyBotCount;
+   NearbyBotState nearbyBots[MAX_NEARBY_BOTS];
 
    // variables related to tracking of other players /////////////
    //	short track_reason;  // why the bot is tracking who they are(not used yet)
@@ -634,6 +645,7 @@ enum entity_waterlevels {
 };
 
 #define MAX_BOTS 32
+#define MAX_NEARBY_BOTS 4
 
 #define MAX_TEAMS 32
 #define MAX_TEAMNAME_LENGTH 16

--- a/bot_fsm.cpp
+++ b/bot_fsm.cpp
@@ -4,6 +4,7 @@
 #include "bot_job_think.h"
 #include "bot_markov.h"
 #include "bot_job_functions.h"
+#include "bot_func.h"
 
 extern chatClass chat;
 extern int bot_chat;
@@ -18,6 +19,9 @@ static unsigned gCombatCounts[COMBAT_STATE_COUNT][COMBAT_STATE_COUNT];
 static unsigned gAimCounts[AIM_STATE_COUNT][AIM_STATE_COUNT];
 static unsigned gNavCounts[NAV_STATE_COUNT][NAV_STATE_COUNT];
 static unsigned gReactionCounts[REACT_STATE_COUNT][REACT_STATE_COUNT];
+
+TeamSignalType g_teamSignals[MAX_TEAMS];
+float g_teamSignalExpire[MAX_TEAMS];
 
 float gBotAccuracy[32];
 float gBotReaction[32];
@@ -559,6 +563,8 @@ void BotUpdateChat(bot_t *pBot) {
 
 void BotUpdateCombat(bot_t *pBot) {
     if(!pBot) return;
+    BotRecordNearbyBots(pBot);
+    TeamSignalType sig = BotCurrentSignal(pBot->current_team);
 
     CombatState next = CombatFSMNextState(&pBot->combatFsm);
 
@@ -589,6 +595,19 @@ void BotUpdateCombat(bot_t *pBot) {
                 pBot->visAllyCount > pBot->visEnemyCount + 1)
             next = COMBAT_APPROACH;
     }
+    else {
+        edict_t *shared = BotGetSharedEnemy(pBot);
+        if(shared) {
+            pBot->enemy.ptr = shared;
+            next = COMBAT_APPROACH;
+        }
+    }
+
+    if(sig == SIG_ATTACK)
+        next = COMBAT_ATTACK;
+
+    if(next == COMBAT_ATTACK && pBot->enemy.ptr)
+        BotBroadcastSignal(pBot->current_team, SIG_ATTACK, 0.5f);
 
     pBot->desired_combat_state = static_cast<int>(next);
 }
@@ -676,6 +695,8 @@ NavState NavFSMNextState(NavFSM *fsm) {
 
 void BotUpdateNavigation(bot_t *pBot) {
     if(!pBot) return;
+    BotRecordNearbyBots(pBot);
+    TeamSignalType sig = BotCurrentSignal(pBot->current_team);
     NavState next = NavFSMNextState(&pBot->navFsm);
 
     if(pBot->enemy.ptr) {
@@ -686,8 +707,15 @@ void BotUpdateNavigation(bot_t *pBot) {
                 next = NAV_STRAFE;
         }
     }
+    else {
+        edict_t *shared = BotGetSharedEnemy(pBot);
+        if(shared)
+            pBot->enemy.ptr = shared;
+    }
 
-    if(pBot->desired_reaction_state == REACT_PANIC)
+    if(sig == SIG_ATTACK && pBot->enemy.ptr)
+        next = NAV_STRAFE;
+    else if(pBot->desired_reaction_state == REACT_PANIC)
         next = NAV_STRAFE;
     pBot->desired_nav_state = static_cast<int>(next);
 }
@@ -791,4 +819,58 @@ void BotUpdateReaction(bot_t *pBot) {
         next = REACT_PANIC;
 
     pBot->desired_reaction_state = static_cast<int>(next);
+}
+
+void BotRecordNearbyBots(bot_t *pBot) {
+    if(!pBot) return;
+    pBot->nearbyBotCount = 0;
+    for(int i=0;i<MAX_BOTS && pBot->nearbyBotCount < MAX_NEARBY_BOTS;i++) {
+        bot_t *other = &bots[i];
+        if(!other->is_used || other == pBot)
+            continue;
+        if(other->current_team != pBot->current_team)
+            continue;
+        if((other->pEdict->v.origin - pBot->pEdict->v.origin).Length() > 600.0f)
+            continue;
+        NearbyBotState &info = pBot->nearbyBots[pBot->nearbyBotCount++];
+        info.bot = other->pEdict;
+        info.enemy = other->enemy.ptr;
+        info.combat_state = other->desired_combat_state;
+        info.nav_state = other->desired_nav_state;
+        info.last_update = pBot->f_think_time;
+    }
+}
+
+edict_t *BotGetSharedEnemy(const bot_t *pBot) {
+    int bestCount = 0;
+    edict_t *best = nullptr;
+    for(int i=0;i<pBot->nearbyBotCount;i++) {
+        edict_t *enemy = pBot->nearbyBots[i].enemy;
+        if(!enemy) continue;
+        int count = 1;
+        for(int j=i+1;j<pBot->nearbyBotCount;j++) {
+            if(pBot->nearbyBots[j].enemy == enemy)
+                ++count;
+        }
+        if(count > bestCount) {
+            bestCount = count;
+            best = enemy;
+        }
+    }
+    if(bestCount > 1)
+        return best;
+    return nullptr;
+}
+
+void BotBroadcastSignal(int team, TeamSignalType signal, float duration) {
+    if(team < 0 || team >= MAX_TEAMS) return;
+    g_teamSignals[team] = signal;
+    g_teamSignalExpire[team] = gpGlobals->time + duration;
+}
+
+TeamSignalType BotCurrentSignal(int team) {
+    if(team < 0 || team >= MAX_TEAMS) return SIG_NONE;
+    if(gpGlobals->time > g_teamSignalExpire[team])
+        g_teamSignals[team] = SIG_NONE;
+    return g_teamSignals[team];
 }

--- a/bot_func.h
+++ b/bot_func.h
@@ -30,6 +30,13 @@
 
 #include "bot_fsm.h"
 
+enum TeamSignalType { SIG_NONE = 0, SIG_ATTACK };
+
+void BotRecordNearbyBots(bot_t *pBot);
+edict_t *BotGetSharedEnemy(const bot_t *pBot);
+void BotBroadcastSignal(int team, TeamSignalType signal, float duration);
+TeamSignalType BotCurrentSignal(int team);
+
 // prototypes of bot functions...
 
 void BotSpawnInit(bot_t *pBot);


### PR DESCRIPTION
## Summary
- extend `bot_t` with neighbor tracking
- expose helpers and team signals in `bot_func.h`
- implement new helpers and update FSM logic
- coordinate combat and navigation using team signals

## Testing
- `make -n` *(fails: missing build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686f1de22380833098e025d616be1df7