### PR TITLE
Improve periodic save robustness

### DIFF
--- a/bot_fsm.cpp
+++ b/bot_fsm.cpp
@@ -4,6 +4,7 @@
 #include "bot_job_think.h"
 #include "bot_markov.h"
 #include "bot_job_functions.h"
+#include <enginecallback.h>
 
 extern chatClass chat;
 extern int bot_chat;
@@ -25,6 +26,7 @@ float gBotReaction[32];
 static void load_metrics(const char *file) {
     FILE *fp = fopen(file, "rb");
     if(!fp) {
+        UTIL_BotLogPrintf("load_metrics: failed to open %s\n", file);
         for(int i=0;i<32;i++) {
             gBotAccuracy[i] = 0.5f;
             gBotReaction[i] = 0.5f;
@@ -38,7 +40,10 @@ static void load_metrics(const char *file) {
 
 static void save_metrics(const char *file) {
     FILE *fp = fopen(file, "wb");
-    if(!fp) return;
+    if(!fp) {
+        UTIL_BotLogPrintf("save_metrics: failed to open %s\n", file);
+        return;
+    }
     fwrite(gBotAccuracy, sizeof(float), 32, fp);
     fwrite(gBotReaction, sizeof(float), 32, fp);
     fclose(fp);
@@ -47,6 +52,7 @@ static void save_metrics(const char *file) {
 static void load_counts(const char *file, unsigned *counts, int states) {
     FILE *fp = fopen(file, "rb");
     if(!fp) {
+        UTIL_BotLogPrintf("load_counts: failed to open %s\n", file);
         for(int i=0;i<states*states;i++) counts[i]=1;
         return;
     }
@@ -56,7 +62,10 @@ static void load_counts(const char *file, unsigned *counts, int states) {
 
 static void save_counts(const char *file, unsigned *counts, int states) {
     FILE *fp = fopen(file, "wb");
-    if(!fp) return;
+    if(!fp) {
+        UTIL_BotLogPrintf("save_counts: failed to open %s\n", file);
+        return;
+    }
     fwrite(counts, sizeof(unsigned), states*states, fp);
     fclose(fp);
 }
@@ -769,7 +778,10 @@ void FSMPeriodicSave(float currentTime) {
     if(currentTime >= g_fsm_next_save) {
         SaveFSMCounts();
         SaveBotMetrics();
-        g_fsm_next_save = currentTime + 120.0f;
+        float interval = CVAR_GET_FLOAT("bot_save_interval");
+        if(interval <= 0.0f)
+            interval = 120.0f;
+        g_fsm_next_save = currentTime + interval;
     }
 }
 

--- a/dll.cpp
+++ b/dll.cpp
@@ -64,6 +64,7 @@ cvar_t enable_foxbot = {"enable_foxbot", "1", FCVAR_SERVER | FCVAR_UNLOGGED, 0, 
 cvar_t sv_bot = {"bot", "", 0, 0, nullptr};
 cvar_t bot_ping_base = {"bot_ping_base", "60", FCVAR_SERVER | FCVAR_UNLOGGED, 0, nullptr};
 cvar_t bot_ping_spike = {"bot_ping_spike", "120", FCVAR_SERVER | FCVAR_UNLOGGED, 0, nullptr};
+cvar_t bot_save_interval = {"bot_save_interval", "120", FCVAR_SERVER | FCVAR_UNLOGGED, 0, nullptr};
 
 extern GETENTITYAPI other_GetEntityAPI;
 extern GETNEWDLLFUNCTIONS other_GetNewDLLFunctions;
@@ -666,6 +667,7 @@ void GameDLLInit() {
    CVAR_REGISTER(&enable_foxbot);
    CVAR_REGISTER(&bot_ping_base);
    CVAR_REGISTER(&bot_ping_spike);
+   CVAR_REGISTER(&bot_save_interval);
 
    for (int i = 0; i < 32; i++)
       clients[i] = nullptr;


### PR DESCRIPTION
## Summary
- log failures when Markov/FSM saves or loads fail
- add CVAR `bot_save_interval` and use it for periodic saves

## Testing
- `make -j2` *(fails: fatal error: bits/libc-header-start.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686f1df32c448330874ae87915c538f1