### PR TITLE
Add kill/death streak tracking and taunts

### DIFF
--- a/bot.cpp
+++ b/bot.cpp
@@ -345,6 +345,8 @@ void BotSpawnInit(bot_t *pBot) {
    pBot->bot_has_flag = false;
 
    pBot->scoreAtSpawn = static_cast<int>(pBot->pEdict->v.frags);
+   pBot->killStreak = 0;
+   pBot->deathStreak = 0;
 
    pBot->b_use_health_station = false;
    pBot->f_use_health_time = 0.0;

--- a/bot.h
+++ b/bot.h
@@ -501,6 +501,8 @@ typedef struct {
    bool lockClass;              // set true if you don't want the bots changing class when they feel like it
    short deathsTillClassChange; // remaining deaths till the bot should pick a new class
    int scoreAtSpawn;            // what their score was when they last spawned
+   int killStreak;              // consecutive kills since last death
+   int deathStreak;             // consecutive deaths since last kill
 
    // weapon related variables /////////////////
    float f_shoot_time;         // when to next pull the trigger

--- a/bot_combat.cpp
+++ b/bot_combat.cpp
@@ -35,6 +35,7 @@
 #include "waypoint.h"
 #include "bot_func.h"
 #include "bot_job_think.h"
+#include "bot_job_functions.h"
 #include "bot_navigate.h"
 #include "bot_weapons.h"
 
@@ -246,6 +247,9 @@ void BotMetricOnKill(bot_t *bot) {
    if(bot->accuracy > 1.0f) bot->accuracy = 1.0f;
    bot->reaction_speed += 0.03f;
    if(bot->reaction_speed > 1.0f) bot->reaction_speed = 1.0f;
+   bot->killStreak++;
+   bot->deathStreak = 0;
+   CheckStreakComments(bot);
 }
 
 void BotMetricOnDeath(bot_t *bot) {
@@ -254,6 +258,9 @@ void BotMetricOnDeath(bot_t *bot) {
    if(bot->accuracy < 0.0f) bot->accuracy = 0.0f;
    bot->reaction_speed -= 0.03f;
    if(bot->reaction_speed < 0.0f) bot->reaction_speed = 0.0f;
+   bot->deathStreak++;
+   bot->killStreak = 0;
+   CheckStreakComments(bot);
 }
 
 void BotMetricOnDamage(bot_t *bot, int damage) {

--- a/bot_job_functions.cpp
+++ b/bot_job_functions.cpp
@@ -3580,3 +3580,25 @@ int CountRecentAllyKills(const bot_t *pBot) {
    }
    return kills;
 }
+
+// Trigger chat messages when kill or death streaks reach multiples of three
+void CheckStreakComments(bot_t *pBot) {
+   if (!pBot || !bot_allow_humour)
+      return;
+
+   job_struct *newJob = nullptr;
+
+   if (pBot->killStreak >= 3 && pBot->killStreak % 3 == 0) {
+      newJob = InitialiseNewJob(pBot, JOB_CHAT, true);
+      if (newJob) {
+         snprintf(newJob->message, MAX_CHAT_LENGTH, "On a %d kill streak!", pBot->killStreak);
+         SubmitNewJob(pBot, JOB_CHAT, newJob);
+      }
+   } else if (pBot->deathStreak >= 3 && pBot->deathStreak % 3 == 0) {
+      newJob = InitialiseNewJob(pBot, JOB_CHAT, true);
+      if (newJob) {
+         snprintf(newJob->message, MAX_CHAT_LENGTH, "Ouch %d deaths in a row...", pBot->deathStreak);
+         SubmitNewJob(pBot, JOB_CHAT, newJob);
+      }
+   }
+}

--- a/bot_job_functions.h
+++ b/bot_job_functions.h
@@ -74,6 +74,8 @@ int JobDrownRecover(bot_t *pBot);
 int JobMeleeWarrior(bot_t *pBot);
 int JobGraffitiArtist(bot_t *pBot);
 
+void CheckStreakComments(bot_t *pBot);
+
 float GetAverageAllyHealth(const bot_t *pBot);
 int CountRecentAllyKills(const bot_t *pBot);
 


### PR DESCRIPTION
## Summary
- track kill and death streaks in `bot_t`
- reset streaks at spawn
- emit chat taunts when streak thresholds are reached
- update combat metrics to maintain the streak counters

## Testing
- `make` *(fails: missing binary operator errors)*

------
https://chatgpt.com/codex/tasks/task_e_686f247f0e9c8330b1e416d7ff0fa33b