### PR TITLE
Implement context-aware chat generation

### DIFF
--- a/bot_fsm.cpp
+++ b/bot_fsm.cpp
@@ -561,7 +561,7 @@ void BotUpdateChat(bot_t *pBot) {
         case CHAT_GREET:
             if(!pBot->greeting && pBot->create_time + 3.0 > pBot->f_think_time &&
                random_long(1, 1000) < bot_chat) {
-                MarkovGenerate(newJob->message, MAX_CHAT_LENGTH);
+                strncpy(newJob->message, "@greet", MAX_CHAT_LENGTH);
                 newJob->message[MAX_CHAT_LENGTH-1] = '\0';
                 SubmitNewJob(pBot, JOB_CHAT, newJob);
                 pBot->greeting = true;
@@ -569,9 +569,8 @@ void BotUpdateChat(bot_t *pBot) {
             break;
         case CHAT_KILL:
             if(pBot->killed_edict && random_long(1, 1000) < bot_chat) {
-                MarkovGenerate(newJob->message, MAX_CHAT_LENGTH);
-                size_t len = strlen(newJob->message);
-                snprintf(newJob->message+len, MAX_CHAT_LENGTH-len, " %s", STRING(pBot->killed_edict->v.netname));
+                strncpy(newJob->message, "@kill", MAX_CHAT_LENGTH);
+                newJob->player = pBot->killed_edict;
                 newJob->message[MAX_CHAT_LENGTH-1] = '\0';
                 SubmitNewJob(pBot, JOB_CHAT, newJob);
                 pBot->killed_edict = NULL;
@@ -579,9 +578,8 @@ void BotUpdateChat(bot_t *pBot) {
             break;
         case CHAT_DEATH:
             if(pBot->killer_edict && random_long(1, 1000) < bot_chat) {
-                MarkovGenerate(newJob->message, MAX_CHAT_LENGTH);
-                size_t len = strlen(newJob->message);
-                snprintf(newJob->message+len, MAX_CHAT_LENGTH-len, " %s", STRING(pBot->killer_edict->v.netname));
+                strncpy(newJob->message, "@death", MAX_CHAT_LENGTH);
+                newJob->player = pBot->killer_edict;
                 newJob->message[MAX_CHAT_LENGTH-1] = '\0';
                 SubmitNewJob(pBot, JOB_CHAT, newJob);
                 pBot->killer_edict = NULL;

--- a/bot_job_functions.cpp
+++ b/bot_job_functions.cpp
@@ -275,11 +275,23 @@ int JobChat(bot_t *pBot) {
 
    // end phase - say the message
    if (job_ptr->phase == 1 && job_ptr->phase_timer < pBot->f_think_time) {
-      // just in case!
       job_ptr->message[MAX_CHAT_LENGTH - 1] = '\0';
 
-      UTIL_HostSay(pBot->pEdict, 0, job_ptr->message);
-      MarkovAddSentence(job_ptr->message);
+      if (job_ptr->message[0] == '@') {
+         char gen[MAX_CHAT_LENGTH];
+         MarkovGenerateContextual(job_ptr->message + 1, gen, MAX_CHAT_LENGTH);
+         if (job_ptr->player)
+         {
+            size_t len = strlen(gen);
+            snprintf(gen + len, MAX_CHAT_LENGTH - len, " %s", STRING(job_ptr->player->v.netname));
+            gen[MAX_CHAT_LENGTH - 1] = '\0';
+         }
+         UTIL_HostSay(pBot->pEdict, 0, gen);
+         MarkovAddSentence(gen);
+      } else {
+         UTIL_HostSay(pBot->pEdict, 0, job_ptr->message);
+         MarkovAddSentence(job_ptr->message);
+      }
       return JOB_TERMINATED; // job done
    }
 
@@ -310,11 +322,23 @@ int JobReport(bot_t *pBot) {
 
    // end phase - say the message
    if (job_ptr->phase == 1 && job_ptr->phase_timer < pBot->f_think_time) {
-      // just in case!
       job_ptr->message[MAX_CHAT_LENGTH - 1] = '\0';
 
-      UTIL_HostSay(pBot->pEdict, 1, job_ptr->message);
-      MarkovAddSentence(job_ptr->message);
+      if (job_ptr->message[0] == '@') {
+         char gen[MAX_CHAT_LENGTH];
+         MarkovGenerateContextual(job_ptr->message + 1, gen, MAX_CHAT_LENGTH);
+         if (job_ptr->player)
+         {
+            size_t len = strlen(gen);
+            snprintf(gen + len, MAX_CHAT_LENGTH - len, " %s", STRING(job_ptr->player->v.netname));
+            gen[MAX_CHAT_LENGTH - 1] = '\0';
+         }
+         UTIL_HostSay(pBot->pEdict, 1, gen);
+         MarkovAddSentence(gen);
+      } else {
+         UTIL_HostSay(pBot->pEdict, 1, job_ptr->message);
+         MarkovAddSentence(job_ptr->message);
+      }
       return JOB_TERMINATED; // job done
    }
 

--- a/bot_markov.h
+++ b/bot_markov.h
@@ -6,6 +6,7 @@
 void MarkovInit();
 void MarkovAddSentence(const char *line);
 void MarkovGenerate(char *out, size_t maxLen);
+void MarkovGenerateContextual(const char *context, char *out, size_t maxLen);
 bool MarkovSave(const char *file);
 bool MarkovLoad(const char *file);
 void MarkovPeriodicSave(const char *file, float currentTime);


### PR DESCRIPTION
## Summary
- support contextual Markov phrases
- parse foxbot_chat.txt for category tags
- generate context phrases during JOB_CHAT/JOB_REPORT
- wire up chat FSM with `@greet`, `@kill`, and `@death` contexts

## Testing
- `make` *(fails: missing 32-bit libs)*

------
https://chatgpt.com/codex/tasks/task_e_686f245f0bd4833084532d3d7b19f974