### PR TITLE
Add frustration/excitement metrics

### DIFF
--- a/bot.cpp
+++ b/bot.cpp
@@ -365,6 +365,8 @@ void BotSpawnInit(bot_t *pBot) {
    pBot->scoreAtSpawn = static_cast<int>(pBot->pEdict->v.frags);
    pBot->killStreak = 0;
    pBot->deathStreak = 0;
+   pBot->frustration = 0.0f;
+   pBot->excitement = 0.0f;
 
    pBot->b_use_health_station = false;
    pBot->f_use_health_time = 0.0;
@@ -941,6 +943,8 @@ void BotCreate(edict_t *pPlayer, const char *arg1, const char *arg2, const char 
       }
 
       pBot->f_humour_time = pBot->f_think_time + random_float(60.0, 180.0);
+      pBot->frustration = 0.0f;
+      pBot->excitement = 0.0f;
 
       pBot->sideRouteTolerance = 400; // not willing to branch far initially
 

--- a/bot.h
+++ b/bot.h
@@ -382,6 +382,8 @@ typedef struct {
    AimFSM aimFsm;         // state machine for aiming preference
    ReactionFSM reactFsm;  // state machine for emotional reaction
    float f_humour_time;    // next time the bot may feel like doing something daft
+   float frustration;      // level of frustration (0.0 - 1.0)
+   float excitement;       // level of excitement (0.0 - 1.0)
 
    // buffer for remembering jobs that the bot is interested in doing
    int jobType[JOB_BUFFER_MAX];

--- a/bot_combat.cpp
+++ b/bot_combat.cpp
@@ -247,6 +247,9 @@ void BotMetricOnKill(bot_t *bot) {
    if(bot->accuracy > 1.0f) bot->accuracy = 1.0f;
    bot->reaction_speed += 0.03f;
    if(bot->reaction_speed > 1.0f) bot->reaction_speed = 1.0f;
+   bot->excitement += 0.2f;
+   if(bot->excitement > 1.0f) bot->excitement = 1.0f;
+   bot->frustration *= 0.5f;
    bot->killStreak++;
    bot->deathStreak = 0;
    CheckStreakComments(bot);
@@ -258,6 +261,9 @@ void BotMetricOnDeath(bot_t *bot) {
    if(bot->accuracy < 0.0f) bot->accuracy = 0.0f;
    bot->reaction_speed -= 0.03f;
    if(bot->reaction_speed < 0.0f) bot->reaction_speed = 0.0f;
+   bot->frustration += 0.2f;
+   if(bot->frustration > 1.0f) bot->frustration = 1.0f;
+   bot->excitement *= 0.5f;
    bot->deathStreak++;
    bot->killStreak = 0;
    CheckStreakComments(bot);

--- a/bot_job_functions.cpp
+++ b/bot_job_functions.cpp
@@ -3612,6 +3612,21 @@ void CheckStreakComments(bot_t *pBot) {
 
    job_struct *newJob = nullptr;
 
+   if(pBot->frustration > 0.7f && BufferedJobIndex(pBot, JOB_CHAT) == -1) {
+      newJob = InitialiseNewJob(pBot, JOB_CHAT, true);
+      if(newJob) {
+         snprintf(newJob->message, MAX_CHAT_LENGTH, "I'm getting frustrated!");
+         SubmitNewJob(pBot, JOB_CHAT, newJob);
+      }
+      pBot->desired_combat_state = COMBAT_ATTACK;
+   } else if(pBot->excitement > 0.7f && BufferedJobIndex(pBot, JOB_CHAT) == -1) {
+      newJob = InitialiseNewJob(pBot, JOB_CHAT, true);
+      if(newJob) {
+         snprintf(newJob->message, MAX_CHAT_LENGTH, "Woohoo!");
+         SubmitNewJob(pBot, JOB_CHAT, newJob);
+      }
+   }
+
    if (pBot->killStreak >= 3 && pBot->killStreak % 3 == 0) {
       newJob = InitialiseNewJob(pBot, JOB_CHAT, true);
       if (newJob) {


### PR DESCRIPTION
## Summary
- extend `bot_t` with frustration and excitement fields
- initialise new fields in bot startup
- adjust metrics on kill/death events
- trigger aggressive chat when frustration is high

## Testing
- `make -j$(nproc)` *(fails: missing binary operator before token)*

------
https://chatgpt.com/codex/tasks/task_e_686f2703f6108330b00d1ff86bf8feff