### PR TITLE
Add persistent bot memory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ SRC = 	bot.cpp \
    linkfunc.cpp \
    meta_api.cpp \
    bot_rl.cpp \
+   bot_memory.cpp \
    sdk_util.cpp \
    util.cpp \
    version.cpp \

--- a/bot.cpp
+++ b/bot.cpp
@@ -1000,6 +1000,7 @@ void BotCreate(edict_t *pPlayer, const char *arg1, const char *arg2, const char 
       pBot->dispenser_edict = nullptr;
       pBot->f_dispenserDetTime = 0.0;
       pBot->killer_edict = nullptr;
+      pBot->killer_name[0] = '\0';
       pBot->killed_edict = nullptr;
       pBot->lastEnemySentryGun = nullptr;
       pBot->mission = ROLE_ATTACKER;
@@ -3106,8 +3107,11 @@ static void BotComms(bot_t *pBot) {
          pBot->newmsg = true;
       }
       pBot->killer_edict = nullptr;
-   } else
+      pBot->killer_name[0] = '\0';
+   } else {
       pBot->killer_edict = nullptr;
+      pBot->killer_name[0] = '\0';
+   }
 
    // haha I killed you messages
    if (pBot->killed_edict != nullptr && random_long(1, 1000) < static_cast<long>(bot_chat)) {

--- a/bot.h
+++ b/bot.h
@@ -497,9 +497,10 @@ typedef struct {
 
    float f_bot_spawn_time;      // remembers when the bot last spawned
    float last_spawn_time;       // also remembers when the bot last spawned(dunno why)
-   float f_killed_time;         // remembers when the bot last died
-   edict_t *killer_edict;       // remembers who last killed this bot
-   edict_t *killed_edict;       // remembers who the bot just killed
+  float f_killed_time;         // remembers when the bot last died
+  edict_t *killer_edict;       // remembers who last killed this bot
+  char killer_name[BOT_NAME_LEN + 1]; // name of last killer for persistence
+  edict_t *killed_edict;       // remembers who the bot just killed
    bool lockClass;              // set true if you don't want the bots changing class when they feel like it
    short deathsTillClassChange; // remaining deaths till the bot should pick a new class
    int scoreAtSpawn;            // what their score was when they last spawned
@@ -697,6 +698,7 @@ int UTIL_GetFlagsTeam(const edict_t *flag_edict);
 int UTIL_GetClass(edict_t *pEntity);
 
 int UTIL_GetBotIndex(edict_t *pEdict);
+edict_t *UTIL_PlayerByName(const char *name);
 
 bot_t *UTIL_GetBotPointer(edict_t *pEdict);
 

--- a/bot_client.cpp
+++ b/bot_client.cpp
@@ -640,11 +640,12 @@ void BotClient_Valve_DeathMsg(void *p, int bot_index) {
       // is this message about a bot being killed?
       if (index != -1) {
          if (killer_index == 0 || killer_index == victim_index) {
-            // bot killed by world (worldspawn) or bot killed self...
             bots[index].killer_edict = nullptr;
+            bots[index].killer_name[0] = '\0';
          } else {
-            // store edict of player that killed this bot...
             bots[index].killer_edict = INDEXENT(killer_index);
+            strncpy(bots[index].killer_name, STRING(INDEXENT(killer_index)->v.netname), BOT_NAME_LEN);
+            bots[index].killer_name[BOT_NAME_LEN] = '\0';
             killer_edict = INDEXENT(killer_index);
             indexb = UTIL_GetBotIndex(killer_edict);
             if (indexb != -1 && victim_edict != nullptr) {

--- a/bot_fsm.cpp
+++ b/bot_fsm.cpp
@@ -610,12 +610,15 @@ void BotUpdateChat(bot_t *pBot) {
             }
             break;
         case CHAT_DEATH:
+            if(!pBot->killer_edict && pBot->killer_name[0])
+                pBot->killer_edict = UTIL_PlayerByName(pBot->killer_name);
             if(pBot->killer_edict && random_long(1, 1000) < bot_chat) {
                 strncpy(newJob->message, "@death", MAX_CHAT_LENGTH);
                 newJob->player = pBot->killer_edict;
                 newJob->message[MAX_CHAT_LENGTH-1] = '\0';
                 SubmitNewJob(pBot, JOB_CHAT, newJob);
                 pBot->killer_edict = NULL;
+                pBot->killer_name[0] = '\0';
             }
             break;
         default:

--- a/bot_markov.cpp
+++ b/bot_markov.cpp
@@ -1,5 +1,6 @@
 #include "bot_markov.h"
 #include "bot.h"
+#include "bot_memory.h"
 #include <unordered_map>
 #include <vector>
 #include <string>
@@ -242,6 +243,7 @@ void MarkovPeriodicSave(const char *file, float currentTime) {
                 UTIL_BotLogPrintf("MarkovPeriodicSave: saved %s at %f\n", file, currentTime);
             }
         }
+        SaveBotMemory();
         float interval = CVAR_GET_FLOAT("bot_save_interval");
         if(interval <= 0.0f)
             interval = 120.0f;

--- a/bot_memory.cpp
+++ b/bot_memory.cpp
@@ -1,0 +1,51 @@
+#include "bot_memory.h"
+#include "bot.h"
+#include "util.h"
+#include <cstdio>
+#include <cstring>
+
+static const unsigned MEMORY_FILE_VERSION = 1;
+
+void LoadBotMemory() {
+    char fname[256];
+    UTIL_BuildFileName(fname, 255, (char*)"bot_memory.dat", NULL);
+    FILE *fp = fopen(fname, "rb");
+    if(!fp) {
+        for(int i=0;i<32;i++) {
+            bots[i].killer_name[0] = '\0';
+            for(int j=0;j<MAX_OPPONENTS;j++)
+                memset(&bots[i].opponents[j], 0, sizeof(OpponentInfo));
+        }
+        return;
+    }
+    unsigned version = 0;
+    if(fread(&version, sizeof(unsigned), 1, fp) != 1 || version != MEMORY_FILE_VERSION) {
+        fclose(fp);
+        for(int i=0;i<32;i++) {
+            bots[i].killer_name[0] = '\0';
+            for(int j=0;j<MAX_OPPONENTS;j++)
+                memset(&bots[i].opponents[j], 0, sizeof(OpponentInfo));
+        }
+        return;
+    }
+    for(int i=0;i<32;i++) {
+        fread(bots[i].killer_name, sizeof(char), BOT_NAME_LEN+1, fp);
+        fread(bots[i].opponents, sizeof(OpponentInfo), MAX_OPPONENTS, fp);
+        bots[i].killer_edict = nullptr;
+        bots[i].killed_edict = nullptr;
+    }
+    fclose(fp);
+}
+
+void SaveBotMemory() {
+    char fname[256];
+    UTIL_BuildFileName(fname, 255, (char*)"bot_memory.dat", NULL);
+    FILE *fp = fopen(fname, "wb");
+    if(!fp) return;
+    fwrite(&MEMORY_FILE_VERSION, sizeof(unsigned), 1, fp);
+    for(int i=0;i<32;i++) {
+        fwrite(bots[i].killer_name, sizeof(char), BOT_NAME_LEN+1, fp);
+        fwrite(bots[i].opponents, sizeof(OpponentInfo), MAX_OPPONENTS, fp);
+    }
+    fclose(fp);
+}

--- a/bot_memory.h
+++ b/bot_memory.h
@@ -1,0 +1,7 @@
+#ifndef BOT_MEMORY_H
+#define BOT_MEMORY_H
+
+void LoadBotMemory();
+void SaveBotMemory();
+
+#endif // BOT_MEMORY_H

--- a/dll.cpp
+++ b/dll.cpp
@@ -39,6 +39,7 @@
 #include "bot_rl.h"
 #include "waypoint.h"
 #include "bot_markov.h"
+#include "bot_memory.h"
 
 // meta mod includes
 #include <dllapi.h>
@@ -683,6 +684,7 @@ void GameDLLInit() {
    char mkfile[256];
    UTIL_BuildFileName(mkfile, 255, (char*)"foxbot_markov.dat", NULL);
    MarkovLoad(mkfile);
+   LoadBotMemory();
    LoadFSMCounts();
    LoadBotMetrics();
    // read the chat strings from the bot chat file
@@ -698,6 +700,7 @@ void GameDLLShutdown() {
    char mkfile[256];
    UTIL_BuildFileName(mkfile, 255, (char*)"foxbot_markov.dat", NULL);
    MarkovSave(mkfile);
+   SaveBotMemory();
    for(int i=0;i<32;i++) {
       if(bots[i].is_used)
          RL_RecordRoundEnd(&bots[i].fsm);
@@ -5792,6 +5795,7 @@ static void ClearKickedBotsData(const int botIndex, const bool eraseBotsName) {
    bots[botIndex].lastEnemySentryGun = nullptr;
    bots[botIndex].suspectedSpy = nullptr;
    bots[botIndex].killer_edict = nullptr;
+   bots[botIndex].killer_name[0] = '\0';
    bots[botIndex].killed_edict = nullptr;
    bots[botIndex].has_sentry = false;
    bots[botIndex].sentry_edict = nullptr;

--- a/meson.build
+++ b/meson.build
@@ -204,6 +204,7 @@ sourceFiles = files (
    'linkfunc.cpp',
    'meta_api.cpp',
    'bot_rl.cpp',
+   'bot_memory.cpp',
    'sdk_util.cpp',
    'util.cpp',
    'version.cpp',

--- a/util.cpp
+++ b/util.cpp
@@ -429,6 +429,17 @@ int UTIL_GetBotIndex(edict_t *pEdict) {
    return -1;
 }
 
+edict_t *UTIL_PlayerByName(const char *name) {
+   if (!name || !*name)
+      return nullptr;
+   for (int i = 1; i <= gpGlobals->maxClients; ++i) {
+      edict_t *p = INDEXENT(i);
+      if (p && !p->free && STRING(p->v.netname)[0] && strcasecmp(STRING(p->v.netname), name) == 0)
+         return p;
+   }
+   return nullptr;
+}
+
 bot_t *UTIL_GetBotPointer(edict_t *pEdict) {
    for (int index = 0; index < 32; index++) {
       if (bots[index].pEdict == pEdict)


### PR DESCRIPTION
## Summary
- persist killer IDs and favourite routes to disk
- load this memory on map start and restore killers
- write utility for player lookup by name
- call memory saves during periodic and shutdown saves
- enable compilation of new files

## Testing
- `make -j$(nproc)` *(fails: missing binary operator)*

------
https://chatgpt.com/codex/tasks/task_e_686f2ab9574483309f54ff6759324805