### PR TITLE
Add pathless follow behavior

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1412,3 +1412,4 @@ Jan-16-2001
 -  Spys will attempt to backstab (if disguised)
 
 -  If a bot sees an enemy sentry gun, they will attempt to kill it without being shot
+-  Bots without a path now follow nearby human teammates or investigate combat sounds


### PR DESCRIPTION
## Summary
- follow a nearby human when the bot lacks a waypoint
- document new fallback behaviour in `changelog.txt`

## Testing
- `make` *(fails: missing binary operator before token)*

------
https://chatgpt.com/codex/tasks/task_e_686f2ae5b33c8330a91a0fefef4e9344