### PR TITLE
Implement simple navigation zones

### DIFF
--- a/bot_navigate.h
+++ b/bot_navigate.h
@@ -31,6 +31,9 @@
 // standard amount of time to reach the bots current waypoint
 #define BOT_WP_DEADLINE 7.0
 
+// coarse navigation zones
+enum MapZone { ZONE_UNKNOWN = 0, ZONE_BASE, ZONE_MID, ZONE_ENEMY_BASE };
+
 void BotUpdateHomeInfo(const bot_t *pBot);
 
 void BotFindCurrentWaypoint(bot_t *pBot);


### PR DESCRIPTION
## Summary
- add `MapZone` enum to categorize map areas
- compute zones for each team based on spawn points
- update bots to plan intermediate waypoints when moving across zones

## Testing
- `make` *(fails: missing 32bit libraries)*

------
https://chatgpt.com/codex/tasks/task_e_686f2e6a1d488330a31c11e80c17ca7a