### PR TITLE
Add map spot tracking

### DIFF
--- a/bot_combat.cpp
+++ b/bot_combat.cpp
@@ -243,6 +243,7 @@ void BotUpdateSkillInaccuracy() {
 
 void BotMetricOnKill(bot_t *bot) {
    if(!bot) return;
+   AddAmbushSpot(bot->pEdict->v.origin);
    bot->accuracy += 0.05f;
    if(bot->accuracy > 1.0f) bot->accuracy = 1.0f;
    bot->reaction_speed += 0.03f;
@@ -258,6 +259,7 @@ void BotMetricOnKill(bot_t *bot) {
 
 void BotMetricOnDeath(bot_t *bot) {
    if(!bot) return;
+   AddDangerSpot(bot->pEdict->v.origin);
    bot->accuracy -= 0.05f;
    if(bot->accuracy < 0.0f) bot->accuracy = 0.0f;
    bot->reaction_speed -= 0.03f;

--- a/bot_navigate.cpp
+++ b/bot_navigate.cpp
@@ -36,8 +36,115 @@
 #include "bot_job_think.h"
 #include "bot_navigate.h"
 #include "bot_weapons.h"
+#include <cstdio>
+#include <climits>
 #include <vector>
 #include <algorithm>
+
+struct Spot {
+   Vector origin;
+   int count;
+};
+
+static std::vector<Spot> g_dangerSpots;
+static std::vector<Spot> g_ambushSpots;
+
+static void build_spot_filename(char *out, const char *suffix) {
+   char mapname[64];
+   strncpy(mapname, STRING(gpGlobals->mapname), sizeof(mapname) - 1);
+   mapname[sizeof(mapname) - 1] = '\0';
+   strncat(mapname, suffix, sizeof(mapname) - strlen(mapname) - 1);
+   UTIL_BuildFileName(out, 255, "mapdata", mapname);
+}
+
+static void load_spots(const char *file, std::vector<Spot> &spots) {
+   spots.clear();
+   FILE *fp = fopen(file, "rb");
+   if(!fp) return;
+   unsigned num = 0;
+   if(fread(&num, sizeof(unsigned), 1, fp) == 1) {
+      for(unsigned i=0;i<num;i++) {
+         Spot s{};
+         fread(&s, sizeof(Spot), 1, fp);
+         spots.push_back(s);
+      }
+   }
+   fclose(fp);
+}
+
+static void save_spots(const char *file, const std::vector<Spot> &spots) {
+   FILE *fp = fopen(file, "wb");
+   if(!fp) return;
+   unsigned num = spots.size();
+   fwrite(&num, sizeof(unsigned), 1, fp);
+   for(const Spot &s : spots)
+      fwrite(&s, sizeof(Spot), 1, fp);
+   fclose(fp);
+}
+
+static void LoadDangerSpots() {
+   char fname[256];
+   build_spot_filename(fname, "_danger.dat");
+   load_spots(fname, g_dangerSpots);
+}
+
+static void SaveDangerSpots() {
+   char fname[256];
+   build_spot_filename(fname, "_danger.dat");
+   save_spots(fname, g_dangerSpots);
+}
+
+static void LoadAmbushSpots() {
+   char fname[256];
+   build_spot_filename(fname, "_ambush.dat");
+   load_spots(fname, g_ambushSpots);
+}
+
+static void SaveAmbushSpots() {
+   char fname[256];
+   build_spot_filename(fname, "_ambush.dat");
+   save_spots(fname, g_ambushSpots);
+}
+
+void LoadMapSpotData() {
+   LoadDangerSpots();
+   LoadAmbushSpots();
+}
+
+void SaveMapSpotData() {
+   SaveDangerSpots();
+   SaveAmbushSpots();
+}
+
+void AddDangerSpot(const Vector &pos) {
+   for(auto &s : g_dangerSpots) {
+      if((s.origin - pos).Length() < 128.0f) {
+         if(s.count < INT_MAX) ++s.count;
+         return;
+      }
+   }
+   Spot s{pos,1};
+   g_dangerSpots.push_back(s);
+}
+
+void AddAmbushSpot(const Vector &pos) {
+   for(auto &s : g_ambushSpots) {
+      if((s.origin - pos).Length() < 128.0f) {
+         if(s.count < INT_MAX) ++s.count;
+         return;
+      }
+   }
+   Spot s{pos,1};
+   g_ambushSpots.push_back(s);
+}
+
+bool IsDangerSpot(const Vector &pos) {
+   for(const auto &s : g_dangerSpots) {
+      if((s.origin - pos).Length() < 128.0f)
+         return true;
+   }
+   return false;
+}
 
 extern bot_weapon_t weapon_defs[MAX_WEAPONS];
 extern edict_t *clients[32];
@@ -850,6 +957,15 @@ static bool BotUpdateRoute(bot_t *pBot) {
          nextWP = WaypointRouteFromTo(pBot->current_wp, pBot->goto_wp, pBot->current_team);
       else // bots current goal is a branching waypoint
          nextWP = WaypointRouteFromTo(pBot->current_wp, pBot->branch_waypoint, pBot->current_team);
+
+      if (nextWP != -1 && IsDangerSpot(waypoints[nextWP].origin)) {
+         if (BotChangeRoute(pBot)) {
+            if (pBot->branch_waypoint == -1)
+               nextWP = WaypointRouteFromTo(pBot->current_wp, pBot->goto_wp, pBot->current_team);
+            else
+               nextWP = WaypointRouteFromTo(pBot->current_wp, pBot->branch_waypoint, pBot->current_team);
+         }
+      }
 
       // figure out how near to the bot's current waypoint the bot has to be
       // before it will move on the next waypoint

--- a/bot_navigate.h
+++ b/bot_navigate.h
@@ -87,4 +87,10 @@ int BotDrowningWaypointSearch(const bot_t *pBot);
 
 bool BotFindTeleportShortCut(bot_t *pBot);
 
+void AddDangerSpot(const Vector &pos);
+void AddAmbushSpot(const Vector &pos);
+bool IsDangerSpot(const Vector &pos);
+void LoadMapSpotData();
+void SaveMapSpotData();
+
 #endif // BOT_NAVIGATE_H

--- a/dll.cpp
+++ b/dll.cpp
@@ -37,6 +37,7 @@
 #include "bot_weapons.h"
 #include "bot_fsm.h"
 #include "bot_rl.h"
+#include "bot_navigate.h"
 #include "waypoint.h"
 #include "bot_markov.h"
 #include "bot_memory.h"
@@ -2428,13 +2429,17 @@ void StartFrame() { // v7 last frame timing
    clientdata_s cd;
    int count;
 
+   bool savedSpots = false;
    for(int bi=0; bi<32; ++bi) {
       if(bots[bi].is_used && bots[bi].round_end) {
          RL_RecordRoundEnd(&bots[bi].fsm, &bots[bi]);
          bots[bi].round_end = 0;
          RL_SaveScores();
+         savedSpots = true;
       }
    }
+   if(savedSpots)
+      SaveMapSpotData();
       // if a new map has started then (MUST BE FIRST IN StartFrame)...
       if (strcmp(STRING(gpGlobals->mapname), prevmapname) != 0) {
          first_player = nullptr;
@@ -2933,6 +2938,7 @@ void StartFrame() { // v7 last frame timing
       script_loaded = false;
       script_parsed = false;
       strcpy(prevmapname, STRING(gpGlobals->mapname));
+      LoadMapSpotData();
       char filename[256];
       char mapname[64];
       int i; // reset known team data on map change


### PR DESCRIPTION
## Summary
- store danger and ambush spots per map
- load/save these spots at map transitions and round end
- record kill and death locations
- avoid paths that lead through known danger spots

## Testing
- `make` *(fails: missing binary operator before token)*

------
https://chatgpt.com/codex/tasks/task_e_686f2e553c08833092e49f82b09ef85c