### PR TITLE
Implement path success tracking

### DIFF
--- a/bot_navigate.cpp
+++ b/bot_navigate.cpp
@@ -31,6 +31,7 @@
 #include "bot.h"
 #include "bot_fsm.h"
 #include "waypoint.h"
+#include "bot_rl.h"
 
 #include "bot_func.h"
 #include "bot_job_think.h"
@@ -1298,10 +1299,11 @@ static bool BotUpdateRoute(bot_t *pBot) {
 
       if (waypointTouched) {
          if (nextWP != -1 && nextWP < num_waypoints) {
+            RL_RecordPathResult(pBot->current_wp, nextWP, true);
             new_current_wp = nextWP;
             pBot->routeFailureTally = 0; // all is well, reset this
-         } else                          // bot has no route to it's goal
-         {
+         } else {                        // bot has no route to it's goal
+            RL_RecordPathResult(pBot->current_wp, nextWP, false);
             ++pBot->routeFailureTally; // chalk up another route failure
             new_current_wp = pBot->current_wp;
          }
@@ -1926,6 +1928,9 @@ void BotFindSideRoute(bot_t *pBot) {
    static constexpr WPT_INT32 ignoreFlags = 0 + (W_FL_DELETED | W_FL_AIMING | W_FL_TFC_PL_DEFEND | W_FL_TFC_PIPETRAP | W_FL_TFC_SENTRY | W_FL_SNIPER | W_FL_TFC_DETPACK_CLEAR | W_FL_TFC_DETPACK_SEAL | W_FL_TFC_TELEPORTER_ENTRANCE |
                                              W_FL_TFC_TELEPORTER_EXIT | W_FL_HEALTH | W_FL_ARMOR | W_FL_AMMO | W_FL_TFC_JUMP);
 
+   int bestWP = -1;
+   float bestScore = -1.0f;
+
    // find out if the bot is at a junction waypoint by counting
    // the number of paths connected from it
    PATH *p = paths[pBot->current_wp];
@@ -2034,15 +2039,14 @@ void BotFindSideRoute(bot_t *pBot) {
 
          nextWP = WaypointRouteFromTo(nextWP, i, pBot->current_team);
       }
-
-      // found a suitable waypoint
-      pBot->branch_waypoint = i;
-
-      //	char msg[96]; //DebugMessageOfDoom!
-      //	sprintf(msg, "found a side route, tolerance: %d, re-think in %f seconds",
-      //		pBot->sideRouteTolerance, pBot->f_side_route_time - pBot->f_think_time);
-      //	UTIL_HostSay(pBot->pEdict, 0, msg);
-
+      float score = RL_GetPathWeight(pBot->current_wp, newPredictedWP);
+      if(score > bestScore) {
+         bestScore = score;
+         bestWP = i;
+      }
+   }
+   if(bestWP != -1) {
+      pBot->branch_waypoint = bestWP;
       return;
    }
 }
@@ -2089,6 +2093,7 @@ bool BotChangeRoute(bot_t *pBot) {
 
    // used for remembering the best waypoint found
    int newBranchWP = -1;
+   float bestScore = -1.0f;
 
    // bit field of waypoint types to ignore
    static constexpr WPT_INT32 ignoreFlags = 0 + (W_FL_DELETED | W_FL_AIMING | W_FL_TFC_PL_DEFEND | W_FL_TFC_PIPETRAP | W_FL_TFC_SENTRY | W_FL_SNIPER | W_FL_TFC_TELEPORTER_ENTRANCE | W_FL_TFC_TELEPORTER_EXIT | W_FL_TFC_JUMP | W_FL_LIFT);
@@ -2119,8 +2124,11 @@ bool BotChangeRoute(bot_t *pBot) {
 
       // the best waypoints have no route back through the bot's current waypoint
       if (interimDist == -1) {
-         newBranchWP = index;
-         break;
+         float score = RL_GetPathWeight(pBot->current_wp, newPredictedWP);
+         if(score > bestScore) {
+            bestScore = score;
+            newBranchWP = index;
+         }
       } else {
          // distance from this waypoint to the bots goal
          const int newGoalDistance = WaypointDistanceFromTo(index, goalWP, pBot->current_team);
@@ -2131,9 +2139,12 @@ bool BotChangeRoute(bot_t *pBot) {
          // look for a waypoint that will take the bot nearer to it's goal
          // without coming back through the bots current waypoint
          if (newGoalDistance < maxRouteDistance) {
-            newBranchWP = index;
-            break;
-         }
+            float score = RL_GetPathWeight(pBot->current_wp, newPredictedWP);
+            if(score > bestScore) {
+               bestScore = score;
+               newBranchWP = index;
+            }
+        }
       }
    }
 

--- a/bot_rl.h
+++ b/bot_rl.h
@@ -8,5 +8,7 @@ void RL_LoadScores();
 void RL_SaveScores();
 void RL_RecordRoundEnd(BotFSM *fsm, bot_t *bot);
 float RL_GetStateWeight(BotState state);
+void RL_RecordPathResult(int from, int to, bool success);
+float RL_GetPathWeight(int from, int to);
 
 #endif // BOT_RL_H


### PR DESCRIPTION
## Summary
- track success rates between waypoints
- persist path stats alongside existing RL data
- record path outcomes during navigation
- favor branching routes with higher win ratios

## Testing
- `make` *(fails: missing binary operator before token)*

------
https://chatgpt.com/codex/tasks/task_e_686f3557cbc48330ba0b2da4bc3e8fda