### PR TITLE
Add waypoint cache saving/loading

### DIFF
--- a/dll.cpp
+++ b/dll.cpp
@@ -707,6 +707,7 @@ void GameDLLShutdown() {
          RL_RecordRoundEnd(&bots[i].fsm, &bots[i]);
    }
    RL_SaveScores();
+   WaypointCacheSave();
    SaveFSMCounts();
    SaveBotMetrics();
    if (!mr_meta && other_gFunctionTable.pfnGameShutdown)
@@ -868,7 +869,8 @@ int DispatchSpawn(edict_t *pent) {
          // do level initialization stuff here...
 
          WaypointInit();
-         WaypointLoad(nullptr);
+         if(!WaypointCacheLoad())
+            WaypointLoad(nullptr);
          AreaDefLoad(nullptr);
 
          // my clear var for lev reload..
@@ -2451,8 +2453,10 @@ void StartFrame() { // v7 last frame timing
          savedSpots = true;
       }
    }
-   if(savedSpots)
+   if(savedSpots) {
       SaveMapSpotData();
+      WaypointCacheSave();
+   }
       // if a new map has started then (MUST BE FIRST IN StartFrame)...
       if (strcmp(STRING(gpGlobals->mapname), prevmapname) != 0) {
          first_player = nullptr;

--- a/waypoint.h
+++ b/waypoint.h
@@ -193,6 +193,8 @@ bool WaypointTypeExists(WPT_INT32 flags, int team);
 bool WaypointLoad(edict_t *pEntity);
 
 void WaypointSave();
+bool WaypointCacheSave();
+bool WaypointCacheLoad();
 
 bool WaypointReachable(Vector v_srv, Vector v_dest, const edict_t *pEntity);
 


### PR DESCRIPTION
## Summary
- cache waypoints at round end and shutdown
- load cache on map start if available
- expose `WaypointCacheSave`/`WaypointCacheLoad` APIs

## Testing
- `make -j2` *(fails: missing libraries)*

------
https://chatgpt.com/codex/tasks/task_e_686f38bf9e5c83309320107589218a40